### PR TITLE
Skip only if all changes does skip with passing unit tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,20 @@ The plugin enables deletion of skipped builds. This feature is available for fre
 
 ## How it works
 
-After SCM checkout SCM Skip plugin matches ***last*** commit message with regular expression. For freestyle jobs, the plugin integrates early into lifecycle after SCM checkout. Therefore, nothing is executed on a positive regex match. 
+After SCM checkout SCM Skip plugin matches all commit messages with regular expression. For freestyle jobs, the plugin integrates early into lifecycle after SCM checkout. Therefore, nothing is executed on a positive regex match. 
 
 For pipeline jobs, the plugin can be enabled as a pipeline step and currently cannot be executed earlier in the Jenkins build lifecycle.
 
-If last commit message matches the pattern, the build is aborted (and deleted if enabled). For example, one of the matching messages would be:
+If all the commit message matches the pattern, the build is aborted (and deleted if enabled). For example, one of the matching messages would be:
 - `Updated version. New version: 1.0.1 [ci skip]`
 - `[ci skip] Some changes`
+- `[ci skip]`
+
+
+Example of non skipped build. In this case one of the checkins is not
+meant to be skipped, so the build is not aborted:
+- `Updated version. New version: 1.0.1 [ci skip]`
+- `BUG-135 Some changes`
 - `[ci skip]`
 
 ## Global Configuration

--- a/src/main/java/net/plavcak/jenkins/plugins/scmskip/SCMSkipTools.java
+++ b/src/main/java/net/plavcak/jenkins/plugins/scmskip/SCMSkipTools.java
@@ -91,14 +91,10 @@ public class SCMSkipTools {
             logEmptyChangeLog(logger);
         }
 
-        ChangeLogSet.Entry matchedEntry = null;
-
         boolean allSkipped = true;
         
         for (Object entry : changeLogSet.getItems()) {
-            if (entry instanceof ChangeLogSet.Entry && inspectChangeSetEntry((Entry) entry, matcher)) {
-                matchedEntry = (Entry) entry;
-            } else {
+            if (!entry instanceof ChangeLogSet.Entry && inspectChangeSetEntry((Entry) entry, matcher)) {
                 allSkipped = false;
                 break;
             }

--- a/src/main/java/net/plavcak/jenkins/plugins/scmskip/SCMSkipTools.java
+++ b/src/main/java/net/plavcak/jenkins/plugins/scmskip/SCMSkipTools.java
@@ -93,16 +93,20 @@ public class SCMSkipTools {
 
         ChangeLogSet.Entry matchedEntry = null;
 
+        boolean allSkipped = true;
+        
         for (Object entry : changeLogSet.getItems()) {
             if (entry instanceof ChangeLogSet.Entry && inspectChangeSetEntry((Entry) entry, matcher)) {
                 matchedEntry = (Entry) entry;
+            } else {
+                allSkipped = false;
                 break;
             }
         }
 
         String commitMessage  = combineChangeLogMessages(changeLogSet);
 
-        if (matchedEntry == null) {
+        if (allSkipped) {
             logger.println("SCM Skip: Pattern "
                     + matcher.getPattern().pattern()
                     + " NOT matched on message: "
@@ -126,7 +130,7 @@ public class SCMSkipTools {
             }
         }
 
-        return matchedEntry != null;
+        return allSkipped;
     }
 
     public static void stopBuild(Run<?, ?> run) throws AbortException, IOException, ServletException {

--- a/src/main/java/net/plavcak/jenkins/plugins/scmskip/SCMSkipTools.java
+++ b/src/main/java/net/plavcak/jenkins/plugins/scmskip/SCMSkipTools.java
@@ -92,9 +92,10 @@ public class SCMSkipTools {
         }
 
         boolean allSkipped = true;
-        
+
         for (Object entry : changeLogSet.getItems()) {
-            if (!entry instanceof ChangeLogSet.Entry && inspectChangeSetEntry((Entry) entry, matcher)) {
+            if (!(entry instanceof ChangeLogSet.Entry && inspectChangeSetEntry((Entry) entry, matcher))) {
+                // if any of the changelog messages do not have the matching skip statement, then flag this
                 allSkipped = false;
                 break;
             }

--- a/src/main/java/net/plavcak/jenkins/plugins/scmskip/SCMSkipTools.java
+++ b/src/main/java/net/plavcak/jenkins/plugins/scmskip/SCMSkipTools.java
@@ -106,7 +106,7 @@ public class SCMSkipTools {
 
         String commitMessage  = combineChangeLogMessages(changeLogSet);
 
-        if (allSkipped) {
+        if (!allSkipped) {
             logger.println("SCM Skip: Pattern "
                     + matcher.getPattern().pattern()
                     + " NOT matched on message: "

--- a/src/test/java/net/plavcak/jenkins/plugins/scmskip/SCMSkipBuildStepTest.java
+++ b/src/test/java/net/plavcak/jenkins/plugins/scmskip/SCMSkipBuildStepTest.java
@@ -69,13 +69,12 @@ public class SCMSkipBuildStepTest {
         FreeStyleProject project = createFreestyleProject(null);
 
         FakeChangeLogSCM fakeScm = new FakeChangeLogSCM();
-        fakeScm.addChange().withMsg("Some change [ci skip] in code.");
-        fakeScm.addChange().withMsg("Another change.");
+        fakeScm.addChange().withMsg("Some change [ci skip] in code.\n Another message");
         project.setScm(fakeScm);
 
         FreeStyleBuild build = jenkins.assertBuildStatus(Result.ABORTED, project.scheduleBuild2(0));
         jenkins.assertLogContains("SCM Skip: Pattern .*\\[ci skip\\].* matched on message: "
-            + "Some change [ci skip] in code. Another change.", build);
+            + "Some change [ci skip] in code.", build);
     }
 
     @Test


### PR DESCRIPTION
This is a cleanup of this pull request: https://github.com/jenkinsci/scmskip-plugin/pull/6
I didn't know how to push to that pull request. But feel free to close this and just incorporate there.

That pull request had 2 problems:
1. The logic in SCMSkipTools.java for when to print out log messages about whether things were skipped was inverted.
2. None of the unit tests passed.

Thanks to @jdeniau for the original code. I just made minor changes.
Fixes https://issues.jenkins-ci.org/browse/JENKINS-63918

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue