### PR TITLE
Consider full message for Git changesets

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,11 @@
             <artifactId>pipeline-model-definition</artifactId>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>git</artifactId>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
     <repositories>

--- a/src/main/java/net/plavcak/jenkins/plugins/scmskip/GitMessageExtractor.java
+++ b/src/main/java/net/plavcak/jenkins/plugins/scmskip/GitMessageExtractor.java
@@ -1,0 +1,14 @@
+package net.plavcak.jenkins.plugins.scmskip;
+
+import hudson.plugins.git.GitChangeSet;
+import hudson.scm.ChangeLogSet;
+
+public class GitMessageExtractor {
+	public static String getFullMessage(ChangeLogSet.Entry entry) {
+		if (entry instanceof GitChangeSet) {
+			return ((GitChangeSet) entry).getComment();
+		} else {
+			return entry.getMsg();
+		}
+	}
+}

--- a/src/test/java/net/plavcak/jenkins/plugins/scmskip/GitMessageExtractorTest.java
+++ b/src/test/java/net/plavcak/jenkins/plugins/scmskip/GitMessageExtractorTest.java
@@ -1,0 +1,18 @@
+package net.plavcak.jenkins.plugins.scmskip;
+
+import hudson.plugins.git.GitChangeSet;
+import org.junit.Test;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+
+public class GitMessageExtractorTest {
+
+	@Test
+	public void getFullMessage() {
+		GitChangeSet changeSet = new GitChangeSet(asList(
+				"commit 12345678", "",
+				"    title", "    details [ci skip]"), true);
+		assertEquals("title\ndetails [ci skip]\n", GitMessageExtractor.getFullMessage(changeSet));
+	}
+}


### PR DESCRIPTION
Fixes https://issues.jenkins.io/browse/JENKINS-62751

The `getMsg` method is insufficient for Git messages, `getComment` must be called and an extra class was created so that `git` plugin's code can only be executed when the plugin is installed. 

### Testing done

Automated tests pass.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
