### PR TITLE
Enable Spotless

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,117 +1,122 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+  <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>plugin</artifactId>
-        <version>4.78</version>
-        <relativePath />
-    </parent>
+  <parent>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>plugin</artifactId>
+    <version>4.78</version>
+    <relativePath />
+  </parent>
 
-    <groupId>net.plavcak.jenkins</groupId>
-    <artifactId>scmskip</artifactId>
-    <version>${changelist}</version>
-    <packaging>hpi</packaging>
+  <groupId>net.plavcak.jenkins</groupId>
+  <artifactId>scmskip</artifactId>
+  <version>${changelist}</version>
+  <packaging>hpi</packaging>
 
-    <name>SCM Skip Plugin</name>
-    <url>https://github.com/jenkinsci/scmskip-plugin</url>
-    <licenses>
-        <license>
-            <name>MIT License</name>
-            <url>https://opensource.org/licenses/MIT</url>
-        </license>
-    </licenses>
+  <name>SCM Skip Plugin</name>
+  <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
 
-    <developers>
-      <developer>
-        <id>plavc</id>
-        <name>Gregor Plavčak</name>
-        <email>gregor@plavcak.net</email>
-      </developer>
-    </developers>
+  <licenses>
+    <license>
+      <name>MIT License</name>
+      <url>https://opensource.org/licenses/MIT</url>
+    </license>
+  </licenses>
 
-    <scm>
-        <connection>scm:git:https://github.com/jenkinsci/scmskip-plugin.git</connection>
-        <developerConnection>scm:git:git@github.com:jenkinsci/scmskip-plugin.git</developerConnection>
-        <url>https://github.com/jenkinsci/scmskip-plugin</url>
-        <tag>${scmTag}</tag>
-    </scm>
+  <developers>
+    <developer>
+      <id>plavc</id>
+      <name>Gregor Plavčak</name>
+      <email>gregor@plavcak.net</email>
+    </developer>
+  </developers>
 
-    <properties>
-        <jenkins.version>2.414.3</jenkins.version>
-        <changelist>999999-SNAPSHOT</changelist>
-    </properties>
+  <scm>
+    <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
+    <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+    <tag>${scmTag}</tag>
+    <url>https://github.com/${gitHubRepo}</url>
+  </scm>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.414.x</artifactId>
-                <version>2675.v1515e14da_7a_6</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
+  <properties>
+    <changelist>999999-SNAPSHOT</changelist>
+    <jenkins.version>2.414.3</jenkins.version>
+    <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
+    <spotless.check.skip>false</spotless.check.skip>
+  </properties>
+
+  <dependencyManagement>
     <dependencies>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>structs</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>script-security</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-step-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-job</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-cps</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-basic-steps</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-support</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkinsci.plugins</groupId>
-            <artifactId>pipeline-model-definition</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>git</artifactId>
-            <optional>true</optional>
-        </dependency>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-2.414.x</artifactId>
+        <version>2675.v1515e14da_7a_6</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
     </dependencies>
+  </dependencyManagement>
 
-    <repositories>
-        <repository>
-            <id>repo.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/public/</url>
-        </repository>
-    </repositories>
-    <pluginRepositories>
-        <pluginRepository>
-            <id>repo.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/public/</url>
-        </pluginRepository>
-    </pluginRepositories>
+  <dependencies>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>git</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>structs</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-cps</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-job</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-step-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>script-security</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-basic-steps</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-support</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkinsci.plugins</groupId>
+      <artifactId>pipeline-model-definition</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </repository>
+  </repositories>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
 </project>

--- a/src/main/java/net/plavcak/jenkins/plugins/scmskip/GitMessageExtractor.java
+++ b/src/main/java/net/plavcak/jenkins/plugins/scmskip/GitMessageExtractor.java
@@ -4,11 +4,11 @@ import hudson.plugins.git.GitChangeSet;
 import hudson.scm.ChangeLogSet;
 
 public class GitMessageExtractor {
-	public static String getFullMessage(ChangeLogSet.Entry entry) {
-		if (entry instanceof GitChangeSet) {
-			return ((GitChangeSet) entry).getComment();
-		} else {
-			return entry.getMsg();
-		}
-	}
+    public static String getFullMessage(ChangeLogSet.Entry entry) {
+        if (entry instanceof GitChangeSet) {
+            return ((GitChangeSet) entry).getComment();
+        } else {
+            return entry.getMsg();
+        }
+    }
 }

--- a/src/main/java/net/plavcak/jenkins/plugins/scmskip/SCMSkipBuildStep.java
+++ b/src/main/java/net/plavcak/jenkins/plugins/scmskip/SCMSkipBuildStep.java
@@ -10,6 +10,10 @@ import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.annotation.Nonnull;
 import jenkins.tasks.SimpleBuildStep;
 import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
@@ -17,11 +21,6 @@ import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.StaplerRequest;
-
-import javax.annotation.Nonnull;
-import java.io.IOException;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 public class SCMSkipBuildStep extends Builder implements SimpleBuildStep {
 
@@ -68,8 +67,12 @@ public class SCMSkipBuildStep extends Builder implements SimpleBuildStep {
     }
 
     @Override
-    public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath workspace, @Nonnull EnvVars env,
-                        @Nonnull Launcher launcher, @Nonnull TaskListener listener)
+    public void perform(
+            @Nonnull Run<?, ?> run,
+            @Nonnull FilePath workspace,
+            @Nonnull EnvVars env,
+            @Nonnull Launcher launcher,
+            @Nonnull TaskListener listener)
             throws IOException, FlowInterruptedException {
         if (SCMSkipTools.inspectChangeSetAndCause(run, skipMatcher, listener)) {
             SCMSkipTools.tagRunForDeletion(run, deleteBuild);
@@ -124,6 +127,5 @@ public class SCMSkipBuildStep extends Builder implements SimpleBuildStep {
         public void setSkipPattern(String skipPattern) {
             this.skipPattern = skipPattern;
         }
-
     }
 }

--- a/src/main/java/net/plavcak/jenkins/plugins/scmskip/SCMSkipBuildWrapper.java
+++ b/src/main/java/net/plavcak/jenkins/plugins/scmskip/SCMSkipBuildWrapper.java
@@ -8,16 +8,15 @@ import hudson.model.AbstractProject;
 import hudson.model.BuildListener;
 import hudson.tasks.BuildWrapper;
 import hudson.tasks.BuildWrapperDescriptor;
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.annotation.Nonnull;
 import net.sf.json.JSONObject;
 import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.StaplerRequest;
-
-import javax.annotation.Nonnull;
-import java.io.IOException;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 public class SCMSkipBuildWrapper extends BuildWrapper {
 
@@ -78,7 +77,7 @@ public class SCMSkipBuildWrapper extends BuildWrapper {
             SCMSkipTools.tagRunForDeletion(build, false);
         }
 
-        return new Environment() { };
+        return new Environment() {};
     }
 
     @Override

--- a/src/main/java/net/plavcak/jenkins/plugins/scmskip/SCMSkipConstants.java
+++ b/src/main/java/net/plavcak/jenkins/plugins/scmskip/SCMSkipConstants.java
@@ -4,6 +4,4 @@ public final class SCMSkipConstants {
 
     public static final String DELETE_BUILD = "BUILD_SCM_SKIP_DELETE_BUILD";
     public static final String DEFAULT_PATTERN = ".*\\[ci skip\\].*";
-
-
 }

--- a/src/main/java/net/plavcak/jenkins/plugins/scmskip/SCMSkipDeleteEnvironmentAction.java
+++ b/src/main/java/net/plavcak/jenkins/plugins/scmskip/SCMSkipDeleteEnvironmentAction.java
@@ -3,7 +3,6 @@ package net.plavcak.jenkins.plugins.scmskip;
 import hudson.EnvVars;
 import hudson.model.EnvironmentContributingAction;
 import hudson.model.Run;
-
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
@@ -11,8 +10,7 @@ public class SCMSkipDeleteEnvironmentAction implements EnvironmentContributingAc
 
     private transient boolean deleteBuild;
 
-    public SCMSkipDeleteEnvironmentAction() {
-    }
+    public SCMSkipDeleteEnvironmentAction() {}
 
     public SCMSkipDeleteEnvironmentAction(boolean deleteBuild) {
         this.deleteBuild = deleteBuild;
@@ -45,7 +43,7 @@ public class SCMSkipDeleteEnvironmentAction implements EnvironmentContributingAc
     }
 
     @Override
-    public void buildEnvironment(@Nonnull Run<?,?> run, @Nonnull EnvVars env) {
+    public void buildEnvironment(@Nonnull Run<?, ?> run, @Nonnull EnvVars env) {
         env.put(SCMSkipConstants.DELETE_BUILD, String.valueOf(deleteBuild));
     }
 }

--- a/src/main/java/net/plavcak/jenkins/plugins/scmskip/SCMSkipRunListener.java
+++ b/src/main/java/net/plavcak/jenkins/plugins/scmskip/SCMSkipRunListener.java
@@ -3,7 +3,6 @@ package net.plavcak.jenkins.plugins.scmskip;
 import hudson.Extension;
 import hudson.model.*;
 import hudson.model.listeners.RunListener;
-
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -16,7 +15,7 @@ public class SCMSkipRunListener extends RunListener<AbstractBuild> {
     @Override
     public void onFinalized(AbstractBuild build) {
         try {
-            if (SCMSkipTools.isBuildToDelete((Run)build)) {
+            if (SCMSkipTools.isBuildToDelete((Run) build)) {
                 SCMSkipTools.deleteBuild(build);
             }
         } catch (IOException e) {

--- a/src/main/java/net/plavcak/jenkins/plugins/scmskip/SCMSkipWorkflowRunListener.java
+++ b/src/main/java/net/plavcak/jenkins/plugins/scmskip/SCMSkipWorkflowRunListener.java
@@ -2,10 +2,9 @@ package net.plavcak.jenkins.plugins.scmskip;
 
 import hudson.Extension;
 import hudson.model.listeners.RunListener;
-import org.jenkinsci.plugins.workflow.job.WorkflowRun;
-
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 
 @Extension
 public class SCMSkipWorkflowRunListener extends RunListener<WorkflowRun> {

--- a/src/test/java/net/plavcak/jenkins/plugins/scmskip/GitMessageExtractorTest.java
+++ b/src/test/java/net/plavcak/jenkins/plugins/scmskip/GitMessageExtractorTest.java
@@ -1,18 +1,20 @@
 package net.plavcak.jenkins.plugins.scmskip;
 
-import hudson.plugins.git.GitChangeSet;
-import org.junit.Test;
-
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 
+import hudson.plugins.git.GitChangeSet;
+import org.junit.Test;
+
 public class GitMessageExtractorTest {
 
-	@Test
-	public void getFullMessage() {
-		GitChangeSet changeSet = new GitChangeSet(asList(
-				"commit 12345678", "",
-				"    title", "    details [ci skip]"), true);
-		assertEquals("title\ndetails [ci skip]\n", GitMessageExtractor.getFullMessage(changeSet));
-	}
+    @Test
+    public void getFullMessage() {
+        GitChangeSet changeSet = new GitChangeSet(
+                asList(
+                        "commit 12345678", "",
+                        "    title", "    details [ci skip]"),
+                true);
+        assertEquals("title\ndetails [ci skip]\n", GitMessageExtractor.getFullMessage(changeSet));
+    }
 }

--- a/src/test/java/net/plavcak/jenkins/plugins/scmskip/SCMSkipBuildStepTest.java
+++ b/src/test/java/net/plavcak/jenkins/plugins/scmskip/SCMSkipBuildStepTest.java
@@ -3,13 +3,12 @@ package net.plavcak.jenkins.plugins.scmskip;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Result;
+import java.io.IOException;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.FakeChangeLogSCM;
 import org.jvnet.hudson.test.JenkinsRule;
-
-import java.io.IOException;
 
 public class SCMSkipBuildStepTest {
 
@@ -23,8 +22,7 @@ public class SCMSkipBuildStepTest {
         project = jenkins.configRoundtrip(project);
 
         jenkins.assertEqualDataBoundBeans(
-                new SCMSkipBuildStep(),
-                project.getBuilders().get(0));
+                new SCMSkipBuildStep(), project.getBuilders().get(0));
     }
 
     @Test
@@ -47,7 +45,8 @@ public class SCMSkipBuildStepTest {
         FreeStyleBuild build = jenkins.assertBuildStatus(Result.ABORTED, project.scheduleBuild2(0));
 
         Assert.assertEquals("SCM Skip - build skipped", build.getDescription());
-        jenkins.assertLogContains("SCM Skip: Pattern .*\\[ci skip\\].* matched on message: Some change [ci skip] in code.", build);
+        jenkins.assertLogContains(
+                "SCM Skip: Pattern .*\\[ci skip\\].* matched on message: Some change [ci skip] in code.", build);
     }
 
     @Test
@@ -61,7 +60,9 @@ public class SCMSkipBuildStepTest {
         FreeStyleBuild build = jenkins.assertBuildStatus(Result.ABORTED, project.scheduleBuild2(0));
 
         Assert.assertEquals("SCM Skip - build skipped", build.getDescription());
-        jenkins.assertLogContains("SCM Skip: Pattern .*\\[(ci skip|skip ci)\\].* matched on message: Some change [skip ci] in code.", build);
+        jenkins.assertLogContains(
+                "SCM Skip: Pattern .*\\[(ci skip|skip ci)\\].* matched on message: Some change [skip ci] in code.",
+                build);
     }
 
     @Test
@@ -73,14 +74,15 @@ public class SCMSkipBuildStepTest {
         project.setScm(fakeScm);
 
         FreeStyleBuild build = jenkins.assertBuildStatus(Result.ABORTED, project.scheduleBuild2(0));
-        jenkins.assertLogContains("SCM Skip: Pattern .*\\[ci skip\\].* matched on message: "
-            + "Some change [ci skip] in code.", build);
+        jenkins.assertLogContains(
+                "SCM Skip: Pattern .*\\[ci skip\\].* matched on message: " + "Some change [ci skip] in code.", build);
     }
 
     @Test
     public void testBuildWithGlobalConfiguration() {
 
-        SCMSkipBuildStep.DescriptorImpl descriptor = jenkins.getInstance().getDescriptorByType(SCMSkipBuildStep.DescriptorImpl.class);
+        SCMSkipBuildStep.DescriptorImpl descriptor =
+                jenkins.getInstance().getDescriptorByType(SCMSkipBuildStep.DescriptorImpl.class);
 
         Assert.assertEquals(SCMSkipConstants.DEFAULT_PATTERN, descriptor.getSkipPattern());
 

--- a/src/test/java/net/plavcak/jenkins/plugins/scmskip/SCMSkipBuildWrapperTest.java
+++ b/src/test/java/net/plavcak/jenkins/plugins/scmskip/SCMSkipBuildWrapperTest.java
@@ -7,8 +7,8 @@ import hudson.model.Label;
 import hudson.model.Result;
 import hudson.model.queue.QueueTaskFuture;
 import hudson.tasks.BuildWrapperDescriptor;
-import org.apache.commons.io.IOUtils;
-import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import java.io.IOException;
+import java.net.URL;
 import org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition;
 import org.jenkinsci.plugins.workflow.flow.FlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
@@ -17,10 +17,6 @@ import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URL;
 
 public class SCMSkipBuildWrapperTest {
 
@@ -33,8 +29,7 @@ public class SCMSkipBuildWrapperTest {
 
         BuildWrapperDescriptor descriptor = new SCMSkipBuildWrapper.DescriptorImpl();
 
-        project.getBuildWrappersList().add(
-                new SCMSkipBuildWrapper(false, null));
+        project.getBuildWrappersList().add(new SCMSkipBuildWrapper(false, null));
 
         project = jenkins.configRoundtrip(project);
 
@@ -57,10 +52,9 @@ public class SCMSkipBuildWrapperTest {
     public void testScriptedPipeline() throws Exception {
         String agentLabel = "test-agent";
         jenkins.createOnlineSlave(Label.get(agentLabel));
-        WorkflowJob job = preparePipelineJob("Some change [skip ci] in code.",
-                "Additional change.");
+        WorkflowJob job = preparePipelineJob("Some change [skip ci] in code.", "Additional change.");
 
-        QueueTaskFuture<WorkflowRun> future =job.scheduleBuild2(0);
+        QueueTaskFuture<WorkflowRun> future = job.scheduleBuild2(0);
         Assert.assertNotNull(future);
 
         WorkflowRun completedBuild = jenkins.assertBuildStatus(Result.SUCCESS, future);
@@ -75,7 +69,7 @@ public class SCMSkipBuildWrapperTest {
         Assert.assertNotNull(pipelineFile);
 
         SCMSkipFakeSCM scm = new SCMSkipFakeSCM("Jenkinsfile", pipelineFile);
-        for (String message: commitMessages) {
+        for (String message : commitMessages) {
             scm.addChange().withMsg(message);
         }
         FlowDefinition fd = new CpsScmFlowDefinition(scm, "Jenkinsfile");
@@ -90,13 +84,13 @@ public class SCMSkipBuildWrapperTest {
         jenkins.createOnlineSlave(Label.get(agentLabel));
         WorkflowJob job = preparePipelineJob("Some change [skip ci] in code.\n Additional line.");
 
-        QueueTaskFuture<WorkflowRun> future =job.scheduleBuild2(0);
+        QueueTaskFuture<WorkflowRun> future = job.scheduleBuild2(0);
         Assert.assertNotNull(future);
 
         WorkflowRun completedBuild = jenkins.assertBuildStatus(Result.ABORTED, future);
 
-        String expectedString = "SCM Skip: Pattern .*\\[(ci skip|skip ci)\\].* matched on message: "
-            + "Some change [skip ci] in code.";
+        String expectedString =
+                "SCM Skip: Pattern .*\\[(ci skip|skip ci)\\].* matched on message: " + "Some change [skip ci] in code.";
 
         Assert.assertEquals(completedBuild.getDescription(), "SCM Skip - build skipped");
 
@@ -110,8 +104,7 @@ public class SCMSkipBuildWrapperTest {
         String agentLabel = "test-agent";
         jenkins.createOnlineSlave(Label.get(agentLabel));
         WorkflowJob job = preparePipelineJob("Some change [skip ci] in code.\n Additional line.");
-        QueueTaskFuture<WorkflowRun> future =job.scheduleBuild2(0,
-                new CauseAction(new Cause.UserIdCause()));
+        QueueTaskFuture<WorkflowRun> future = job.scheduleBuild2(0, new CauseAction(new Cause.UserIdCause()));
         Assert.assertNotNull(future);
 
         WorkflowRun completedBuild = jenkins.assertBuildStatus(Result.SUCCESS, future);

--- a/src/test/java/net/plavcak/jenkins/plugins/scmskip/SCMSkipFakeSCM.java
+++ b/src/test/java/net/plavcak/jenkins/plugins/scmskip/SCMSkipFakeSCM.java
@@ -5,15 +5,14 @@ import hudson.Launcher;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.scm.SCMRevisionState;
-import org.apache.commons.io.IOUtils;
-import org.jvnet.hudson.test.FakeChangeLogSCM;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.commons.io.IOUtils;
+import org.jvnet.hudson.test.FakeChangeLogSCM;
 
 public class SCMSkipFakeSCM extends FakeChangeLogSCM {
     private final String path;
@@ -29,6 +28,7 @@ public class SCMSkipFakeSCM extends FakeChangeLogSCM {
         this.contents = IOUtils.toByteArray(resource.openStream());
     }
 
+    @Override
     public EntryImpl addChange() {
         EntryImpl e = new EntryImpl();
         entries.add(e);
@@ -36,12 +36,19 @@ public class SCMSkipFakeSCM extends FakeChangeLogSCM {
     }
 
     @Override
-    public void checkout(Run<?, ?> build, Launcher launcher, FilePath remoteDir, TaskListener listener, File changeLogFile, SCMRevisionState baseline) throws IOException, InterruptedException {
+    public void checkout(
+            Run<?, ?> build,
+            Launcher launcher,
+            FilePath remoteDir,
+            TaskListener listener,
+            File changeLogFile,
+            SCMRevisionState baseline)
+            throws IOException, InterruptedException {
         new FilePath(changeLogFile).touch(0);
         build.addAction(new ChangelogAction(entries, changeLogFile.getName()));
         entries = new ArrayList<>();
 
-        listener.getLogger().println("Staging "+path);
+        listener.getLogger().println("Staging " + path);
         OutputStream os = remoteDir.child(path).write();
         IOUtils.write(contents, os);
         os.close();

--- a/src/test/java/net/plavcak/jenkins/plugins/scmskip/SCMSkipMatcherTest.java
+++ b/src/test/java/net/plavcak/jenkins/plugins/scmskip/SCMSkipMatcherTest.java
@@ -1,9 +1,9 @@
 package net.plavcak.jenkins.plugins.scmskip;
 
+import static org.junit.Assert.*;
+
 import org.junit.Assert;
 import org.junit.Test;
-
-import static org.junit.Assert.*;
 
 public class SCMSkipMatcherTest {
 


### PR DESCRIPTION
Enable the Jenkins project-wide formatting configuration and reformat the existing code. This is a plugin-specific decision, so if the maintainers do not wish to use automatic formatting, this PR can simply be closed.

### Testing done

`mvn clean verify`