### PR TITLE
Added flag to invoke doStop on WorkflowRun instead of throwing FlowInterruptedException

### DIFF
--- a/src/main/java/net/plavcak/jenkins/plugins/scmskip/SCMSkipBuildStep.java
+++ b/src/main/java/net/plavcak/jenkins/plugins/scmskip/SCMSkipBuildStep.java
@@ -29,10 +29,16 @@ public class SCMSkipBuildStep extends Builder implements SimpleBuildStep {
     private SCMSkipMatcher skipMatcher;
     private boolean deleteBuild;
     private String skipPattern;
+    private boolean doStopWorkflowRun;
 
     public SCMSkipBuildStep(boolean deleteBuild, String skipPattern) {
+        this(deleteBuild, skipPattern, false);
+    }
+
+    public SCMSkipBuildStep(boolean deleteBuild, String skipPattern, boolean doStopWorkflowRun) {
         this.deleteBuild = deleteBuild;
         this.skipPattern = skipPattern;
+        this.doStopWorkflowRun = doStopWorkflowRun;
         if (this.skipPattern == null) {
             this.skipPattern = SCMSkipConstants.DEFAULT_PATTERN;
         }
@@ -41,7 +47,7 @@ public class SCMSkipBuildStep extends Builder implements SimpleBuildStep {
 
     @DataBoundConstructor
     public SCMSkipBuildStep() {
-        this(false, null);
+        this(false, null, false);
     }
 
     public boolean isDeleteBuild() {
@@ -66,6 +72,15 @@ public class SCMSkipBuildStep extends Builder implements SimpleBuildStep {
         this.skipMatcher.setPattern(this.skipPattern);
     }
 
+    public boolean isDoStopWorkflowRun() {
+        return doStopWorkflowRun;
+    }
+
+    @DataBoundSetter
+    public void setDoStopWorkflowRun(boolean doStopWorkflowRun) {
+        this.doStopWorkflowRun = doStopWorkflowRun;
+    }
+
     @Override
     public void perform(
             @NonNull Run<?, ?> run,
@@ -78,7 +93,7 @@ public class SCMSkipBuildStep extends Builder implements SimpleBuildStep {
             SCMSkipTools.tagRunForDeletion(run, deleteBuild);
 
             try {
-                SCMSkipTools.stopBuild(run);
+                SCMSkipTools.stopBuild(run, doStopWorkflowRun);
             } catch (AbortException | FlowInterruptedException e) {
                 throw e;
             } catch (Exception e) {

--- a/src/main/java/net/plavcak/jenkins/plugins/scmskip/SCMSkipBuildWrapper.java
+++ b/src/main/java/net/plavcak/jenkins/plugins/scmskip/SCMSkipBuildWrapper.java
@@ -26,11 +26,13 @@ public class SCMSkipBuildWrapper extends BuildWrapper {
     private SCMSkipMatcher skipMatcher;
     private boolean deleteBuild;
     private String skipPattern;
+    private boolean doStopWorkflowRun;
 
     @DataBoundConstructor
-    public SCMSkipBuildWrapper(boolean deleteBuild, String skipPattern) {
+    public SCMSkipBuildWrapper(boolean deleteBuild, String skipPattern, boolean doStopWorkflowRun) {
         this.deleteBuild = deleteBuild;
         this.skipPattern = skipPattern;
+        this.doStopWorkflowRun = doStopWorkflowRun;
         if (this.skipPattern == null) {
             this.skipPattern = SCMSkipConstants.DEFAULT_PATTERN;
         }
@@ -59,6 +61,15 @@ public class SCMSkipBuildWrapper extends BuildWrapper {
         this.skipMatcher.setPattern(this.skipPattern);
     }
 
+    public boolean isDoStopWorkflowRun() {
+        return doStopWorkflowRun;
+    }
+
+    @DataBoundSetter
+    public void setDoStopWorkflowRun(boolean doStopWorkflowRun) {
+        this.doStopWorkflowRun = doStopWorkflowRun;
+    }
+
     @Override
     public Environment setUp(AbstractBuild build, Launcher launcher, BuildListener listener)
             throws IOException, FlowInterruptedException {
@@ -66,7 +77,7 @@ public class SCMSkipBuildWrapper extends BuildWrapper {
             SCMSkipTools.tagRunForDeletion(build, deleteBuild);
 
             try {
-                SCMSkipTools.stopBuild(build);
+                SCMSkipTools.stopBuild(build, doStopWorkflowRun);
             } catch (AbortException | FlowInterruptedException e) {
                 throw e;
             } catch (Exception e) {

--- a/src/test/resources/testDoStopWorkflowRun.Jenkinsfile
+++ b/src/test/resources/testDoStopWorkflowRun.Jenkinsfile
@@ -1,0 +1,13 @@
+pipeline {
+    agent any
+
+    stages {
+        stage('Build') {
+            steps {
+                echo 'before skip'
+                scmSkip(skipPattern: '.*\\[(ci skip|skip ci)\\].*', doStopWorkflowRun: true)
+                echo 'after skip'
+            }
+        }
+    }
+}


### PR DESCRIPTION
Currently the scmSkip does not work as expected in our multi branch pipeline. The build continues to run and only is properly aborted sometimes. Still aborting the build in the JenkinsUI does work. Thus I added a backwards compatible flag to invoke the doStop on a WorkflowRun instead of throwing an execption.

### Testing done

Added new unit test to cover new flag

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

