### PR TITLE
Do not require an agent to execute

### DIFF
--- a/src/main/java/net/plavcak/jenkins/plugins/scmskip/SCMSkipBuildStep.java
+++ b/src/main/java/net/plavcak/jenkins/plugins/scmskip/SCMSkipBuildStep.java
@@ -4,8 +4,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.AbortException;
 import hudson.EnvVars;
 import hudson.Extension;
-import hudson.FilePath;
-import hudson.Launcher;
 import hudson.model.AbstractProject;
 import hudson.model.Run;
 import hudson.model.TaskListener;
@@ -67,12 +65,7 @@ public class SCMSkipBuildStep extends Builder implements SimpleBuildStep {
     }
 
     @Override
-    public void perform(
-            @NonNull Run<?, ?> run,
-            @NonNull FilePath workspace,
-            @NonNull EnvVars env,
-            @NonNull Launcher launcher,
-            @NonNull TaskListener listener)
+    public void perform(@NonNull Run<?, ?> run, @NonNull EnvVars env, @NonNull TaskListener listener)
             throws IOException, FlowInterruptedException {
         if (SCMSkipTools.inspectChangeSetAndCause(run, skipMatcher, listener)) {
             SCMSkipTools.tagRunForDeletion(run, deleteBuild);
@@ -87,6 +80,11 @@ public class SCMSkipBuildStep extends Builder implements SimpleBuildStep {
         } else {
             SCMSkipTools.tagRunForDeletion(run, false);
         }
+    }
+
+    @Override
+    public boolean requiresWorkspace() {
+        return false;
     }
 
     @Override

--- a/src/test/java/net/plavcak/jenkins/plugins/scmskip/SCMSkipBuildStepTest.java
+++ b/src/test/java/net/plavcak/jenkins/plugins/scmskip/SCMSkipBuildStepTest.java
@@ -1,9 +1,21 @@
 package net.plavcak.jenkins.plugins.scmskip;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import hudson.model.Cause;
+import hudson.model.CauseAction;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
+import hudson.model.Label;
 import hudson.model.Result;
+import hudson.model.queue.QueueTaskFuture;
 import java.io.IOException;
+import java.net.URL;
+import java.util.List;
+import org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition;
+import org.jenkinsci.plugins.workflow.flow.FlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -91,6 +103,112 @@ public class SCMSkipBuildStepTest {
         descriptor = jenkins.getInstance().getDescriptorByType(SCMSkipBuildStep.DescriptorImpl.class);
 
         Assert.assertEquals(".*\\[skip-ci\\].*", descriptor.getSkipPattern());
+    }
+
+    @Test
+    public void testScriptedPipelineEmptyChangeLog() throws Exception {
+        String agentLabel = "test-agent";
+        jenkins.createOnlineSlave(Label.get(agentLabel));
+        WorkflowJob job = preparePipelineJob();
+        WorkflowRun completedBuild = jenkins.assertBuildStatusSuccess(job.scheduleBuild2(0));
+        String expectedString = "SCM Skip: Changelog is empty!";
+        jenkins.assertLogContains(expectedString, completedBuild);
+    }
+
+    @Test
+    public void testScriptedPipeline() throws Exception {
+        String agentLabel = "test-agent";
+        jenkins.createOnlineSlave(Label.get(agentLabel));
+        WorkflowJob job = preparePipelineJob("Some change [skip ci] in code.", "Additional change.");
+
+        QueueTaskFuture<WorkflowRun> future = job.scheduleBuild2(0);
+        Assert.assertNotNull(future);
+
+        WorkflowRun completedBuild = jenkins.assertBuildStatus(Result.SUCCESS, future);
+        jenkins.assertLogContains("after skip", completedBuild);
+    }
+
+    @Test
+    public void testScriptedPipelineNoAgent() throws Exception {
+        WorkflowJob job = preparePipelineJob(
+                this.getClass().getClassLoader().getResource("testNoAgent.Jenkinsfile"),
+                "Some change [skip ci] in code.",
+                "Additional change.");
+
+        QueueTaskFuture<WorkflowRun> future = job.scheduleBuild2(0);
+        Assert.assertNotNull(future);
+
+        WorkflowRun completedBuild = jenkins.assertBuildStatus(Result.SUCCESS, future);
+        jenkins.assertLogContains("after skip", completedBuild);
+    }
+
+    @Test
+    public void testScriptedPipelineMultilineCommit() throws Exception {
+        String agentLabel = "test-agent";
+        jenkins.createOnlineSlave(Label.get(agentLabel));
+        WorkflowJob job = preparePipelineJob("Some change [skip ci] in code.\n Additional line.");
+
+        QueueTaskFuture<WorkflowRun> future = job.scheduleBuild2(0);
+        Assert.assertNotNull(future);
+
+        WorkflowRun completedBuild = jenkins.assertBuildStatus(Result.ABORTED, future);
+
+        String expectedString =
+                "SCM Skip: Pattern .*\\[(ci skip|skip ci)\\].* matched on message: " + "Some change [skip ci] in code.";
+
+        Assert.assertEquals("SCM Skip - build skipped", completedBuild.getDescription());
+
+        jenkins.assertLogContains(expectedString, completedBuild);
+        jenkins.assertLogContains("before skip", completedBuild);
+        jenkins.assertLogNotContains("after skip", completedBuild);
+    }
+
+    @Test
+    public void testScriptedPipelineMultilineDelete() throws Exception {
+        String agentLabel = "test-agent";
+        jenkins.createOnlineSlave(Label.get(agentLabel));
+        WorkflowJob job = preparePipelineJob(
+                getClass().getClassLoader().getResource("testDelete.Jenkinsfile"),
+                "Some change [skip ci] in code.\n Additional line.");
+
+        QueueTaskFuture<WorkflowRun> future = job.scheduleBuild2(0);
+        Assert.assertNotNull(future);
+
+        WorkflowRun completedBuild = jenkins.assertBuildStatus(Result.ABORTED, future);
+        Assert.assertEquals("SCM Skip - build skipped", completedBuild.getDescription());
+
+        assertEquals("", JenkinsRule.getLog(completedBuild), "Should delete log");
+        assertEquals(List.of(), job.getBuilds());
+    }
+
+    @Test
+    public void testPipelineUserIdCause() throws Exception {
+        String agentLabel = "test-agent";
+        jenkins.createOnlineSlave(Label.get(agentLabel));
+        WorkflowJob job = preparePipelineJob("Some change [skip ci] in code.\n Additional line.");
+        QueueTaskFuture<WorkflowRun> future = job.scheduleBuild2(0, new CauseAction(new Cause.UserIdCause()));
+        Assert.assertNotNull(future);
+
+        WorkflowRun completedBuild = jenkins.assertBuildStatus(Result.SUCCESS, future);
+        jenkins.assertLogContains("after skip", completedBuild);
+    }
+
+    private WorkflowJob preparePipelineJob(String... commitMessages) throws IOException {
+        return preparePipelineJob(this.getClass().getClassLoader().getResource("test.Jenkinsfile"), commitMessages);
+    }
+
+    private WorkflowJob preparePipelineJob(URL pipelineFile, String... commitMessages) throws IOException {
+        WorkflowJob job = jenkins.createProject(WorkflowJob.class, "test-scripted-pipeline");
+        Assert.assertNotNull(pipelineFile);
+
+        SCMSkipFakeSCM scm = new SCMSkipFakeSCM("Jenkinsfile", pipelineFile);
+        for (String message : commitMessages) {
+            scm.addChange().withMsg(message);
+        }
+        FlowDefinition fd = new CpsScmFlowDefinition(scm, "Jenkinsfile");
+
+        job.setDefinition(fd);
+        return job;
     }
 
     private FreeStyleProject createFreestyleProject(String skipPattern) throws IOException {

--- a/src/test/java/net/plavcak/jenkins/plugins/scmskip/SCMSkipBuildWrapperTest.java
+++ b/src/test/java/net/plavcak/jenkins/plugins/scmskip/SCMSkipBuildWrapperTest.java
@@ -2,22 +2,11 @@ package net.plavcak.jenkins.plugins.scmskip;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import hudson.model.Cause;
-import hudson.model.CauseAction;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
-import hudson.model.Label;
 import hudson.model.Result;
-import hudson.model.queue.QueueTaskFuture;
 import hudson.tasks.BuildWrapperDescriptor;
 import java.io.IOException;
-import java.net.URL;
-import java.util.List;
-import org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition;
-import org.jenkinsci.plugins.workflow.flow.FlowDefinition;
-import org.jenkinsci.plugins.workflow.job.WorkflowJob;
-import org.jenkinsci.plugins.workflow.job.WorkflowRun;
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.FakeChangeLogSCM;
@@ -41,47 +30,6 @@ public class SCMSkipBuildWrapperTest {
         jenkins.assertEqualDataBoundBeans(
                 new SCMSkipBuildWrapper(false, null),
                 project.getBuildWrappersList().get(0));
-    }
-
-    @Test
-    public void testScriptedPipelineEmptyChangeLog() throws Exception {
-        String agentLabel = "test-agent";
-        jenkins.createOnlineSlave(Label.get(agentLabel));
-        WorkflowJob job = preparePipelineJob();
-        WorkflowRun completedBuild = jenkins.assertBuildStatusSuccess(job.scheduleBuild2(0));
-        String expectedString = "SCM Skip: Changelog is empty!";
-        jenkins.assertLogContains(expectedString, completedBuild);
-    }
-
-    @Test
-    public void testScriptedPipeline() throws Exception {
-        String agentLabel = "test-agent";
-        jenkins.createOnlineSlave(Label.get(agentLabel));
-        WorkflowJob job = preparePipelineJob("Some change [skip ci] in code.", "Additional change.");
-
-        QueueTaskFuture<WorkflowRun> future = job.scheduleBuild2(0);
-        Assert.assertNotNull(future);
-
-        WorkflowRun completedBuild = jenkins.assertBuildStatus(Result.SUCCESS, future);
-        jenkins.assertLogContains("after skip", completedBuild);
-    }
-
-    private WorkflowJob preparePipelineJob(String... commitMessages) throws IOException {
-        return preparePipelineJob(this.getClass().getClassLoader().getResource("test.Jenkinsfile"), commitMessages);
-    }
-
-    private WorkflowJob preparePipelineJob(URL pipelineFile, String... commitMessages) throws IOException {
-        WorkflowJob job = jenkins.createProject(WorkflowJob.class, "test-scripted-pipeline");
-        Assert.assertNotNull(pipelineFile);
-
-        SCMSkipFakeSCM scm = new SCMSkipFakeSCM("Jenkinsfile", pipelineFile);
-        for (String message : commitMessages) {
-            scm.addChange().withMsg(message);
-        }
-        FlowDefinition fd = new CpsScmFlowDefinition(scm, "Jenkinsfile");
-
-        job.setDefinition(fd);
-        return job;
     }
 
     private FreeStyleProject createFreestyleProject(boolean delete) throws IOException {
@@ -108,56 +56,5 @@ public class SCMSkipBuildWrapperTest {
         FreeStyleProject project = createFreestyleProject(true);
         FreeStyleBuild build = jenkins.assertBuildStatus(Result.ABORTED, project.scheduleBuild2(0));
         assertEquals("", JenkinsRule.getLog(build), "Should delete log");
-    }
-
-    @Test
-    public void testScriptedPipelineMultilineCommit() throws Exception {
-        String agentLabel = "test-agent";
-        jenkins.createOnlineSlave(Label.get(agentLabel));
-        WorkflowJob job = preparePipelineJob("Some change [skip ci] in code.\n Additional line.");
-
-        QueueTaskFuture<WorkflowRun> future = job.scheduleBuild2(0);
-        Assert.assertNotNull(future);
-
-        WorkflowRun completedBuild = jenkins.assertBuildStatus(Result.ABORTED, future);
-
-        String expectedString =
-                "SCM Skip: Pattern .*\\[(ci skip|skip ci)\\].* matched on message: " + "Some change [skip ci] in code.";
-
-        Assert.assertEquals(completedBuild.getDescription(), "SCM Skip - build skipped");
-
-        jenkins.assertLogContains(expectedString, completedBuild);
-        jenkins.assertLogContains("before skip", completedBuild);
-        jenkins.assertLogNotContains("after skip", completedBuild);
-    }
-
-    @Test
-    public void testScriptedPipelineMultilineDelete() throws Exception {
-        String agentLabel = "test-agent";
-        jenkins.createOnlineSlave(Label.get(agentLabel));
-        WorkflowJob job = preparePipelineJob(
-                getClass().getClassLoader().getResource("testDelete.Jenkinsfile"),
-                "Some change [skip ci] in code.\n Additional line.");
-
-        QueueTaskFuture<WorkflowRun> future = job.scheduleBuild2(0);
-        Assert.assertNotNull(future);
-
-        WorkflowRun completedBuild = jenkins.assertBuildStatus(Result.ABORTED, future);
-        Assert.assertEquals(completedBuild.getDescription(), "SCM Skip - build skipped");
-
-        assertEquals("", JenkinsRule.getLog(completedBuild), "Should delete log");
-        assertEquals(List.of(), job.getBuilds());
-    }
-
-    @Test
-    public void testPipelineUserIdCause() throws Exception {
-        String agentLabel = "test-agent";
-        jenkins.createOnlineSlave(Label.get(agentLabel));
-        WorkflowJob job = preparePipelineJob("Some change [skip ci] in code.\n Additional line.");
-        QueueTaskFuture<WorkflowRun> future = job.scheduleBuild2(0, new CauseAction(new Cause.UserIdCause()));
-        Assert.assertNotNull(future);
-
-        WorkflowRun completedBuild = jenkins.assertBuildStatus(Result.SUCCESS, future);
-        jenkins.assertLogContains("after skip", completedBuild);
     }
 }

--- a/src/test/resources/testNoAgent.Jenkinsfile
+++ b/src/test/resources/testNoAgent.Jenkinsfile
@@ -1,0 +1,13 @@
+pipeline {
+    agent none
+
+    stages {
+        stage('Build') {
+            steps {
+                echo "before skip"
+                scmSkip(skipPattern: '.*\\[(ci skip|skip ci)\\].*')
+                echo "after skip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
The step does not need a workspace and should not require it. Currently the changelog computation does require an agent, but if that changes in the future this would allow skipping the build ea

### Testing done

Automated tests passing.

